### PR TITLE
[1.x] Remove unused capture groups

### DIFF
--- a/src/Rules/ValidBitcoinAddress.php
+++ b/src/Rules/ValidBitcoinAddress.php
@@ -15,7 +15,7 @@ class ValidBitcoinAddress implements Rule
      */
     public function passes($attribute, $value)
     {
-        return preg_match('/^(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}$/', $value);
+        return preg_match('/^(?:bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}$/', $value);
     }
 
     /**

--- a/src/Rules/ValidHexColor.php
+++ b/src/Rules/ValidHexColor.php
@@ -15,7 +15,7 @@ class ValidHexColor implements Rule
      */
     public function passes($attribute, $value)
     {
-        return preg_match('/^#?([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$/', $value);
+        return preg_match('/^#?(?:[a-fA-F0-9]{6}|[a-fA-F0-9]{3})$/', $value);
     }
 
     /**

--- a/src/Rules/ValidIpAddressIPV4.php
+++ b/src/Rules/ValidIpAddressIPV4.php
@@ -15,7 +15,7 @@ class ValidIpAddressIPV4 implements Rule
      */
     public function passes($attribute, $value)
     {
-        return preg_match('/(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}/', $value);
+        return preg_match('/(?:\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(?:\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}/', $value);
     }
 
     /**

--- a/src/Utils/CountryPhoneCallback.php
+++ b/src/Utils/CountryPhoneCallback.php
@@ -17,42 +17,42 @@ class CountryPhoneCallback
 
     protected function validateTG()
     {
-        return preg_match('/^(\+228|00228|228)?\d{8}$/', $this->value);
+        return preg_match('/^(?:\+228|00228|228)?\d{8}$/', $this->value);
     }
 
     protected function validateNE()
     {
-        return preg_match('/^(\+227|00227|227)?\d{8}$/', $this->value);
+        return preg_match('/^(?:\+227|00227|227)?\d{8}$/', $this->value);
     }
 
     protected function validateGW()
     {
-        return preg_match('/^(\+245|00245|245)?\d{7,8}$/', $this->value);
+        return preg_match('/^(?:\+245|00245|245)?\d{7,8}$/', $this->value);
     }
 
     protected function validateTD()
     {
-        return preg_match('/^(\+235|00235|235)?\d{8}$/', $this->value);
+        return preg_match('/^(?:\+235|00235|235)?\d{8}$/', $this->value);
     }
 
     protected function validateCM()
     {
-        return preg_match('/^(\+237|00237|237)?\d{8}$/', $this->value);
+        return preg_match('/^(?:\+237|00237|237)?\d{8}$/', $this->value);
     }
 
     protected function validateBF()
     {
-        return preg_match('/^(\+226|00226|226)?\d{8}$/', $this->value);
+        return preg_match('/^(?:\+226|00226|226)?\d{8}$/', $this->value);
     }
 
     protected function validateAO(): bool
     {
-        return preg_match('/^(\+244|00244|244)?[9,2][1-9]\d{7}$/', $this->value);
+        return preg_match('/^(?:\+244|00244|244)?[9,2][1-9]\d{7}$/', $this->value);
     }
 
     protected function validateBJ(): bool
     {
-        return preg_match('/^(\+229|00229|229)?\d{8}$/', $this->value);
+        return preg_match('/^(?:\+229|00229|229)?\d{8}$/', $this->value);
     }
 
     /**
@@ -71,7 +71,7 @@ class CountryPhoneCallback
         $codes = array_map('strtoupper', $codes);
 
         foreach ($codes as $code) {
-            $methodName = 'validate'.$code;
+            $methodName = 'validate' . $code;
 
             if (method_exists($this, $methodName)) {
                 $results[$code] = $this->{$methodName}();


### PR DESCRIPTION
With this Pull Request some of the capture groups that are not needed will be turned into non-capture groups.

From my research, I can't see any major performance difference in the two methods, but I guess it can't hurt to add this.

_**FYI:** I tested this with the existing test in this repository but not in any real word projects or scenarios_