### PR TITLE
[1.x] Implement DIP for phone/landline validators.

### DIFF
--- a/src/Utils/CountryLandlineCallback.php
+++ b/src/Utils/CountryLandlineCallback.php
@@ -2,7 +2,6 @@
 
 namespace Milwad\LaravelValidate\Utils;
 
-use Milwad\LaravelValidate\Utils\CountryLandlineValidator\CountryLandlineValidator;
 use RuntimeException;
 
 class CountryLandlineCallback

--- a/src/Utils/CountryLandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+namespace Milwad\LaravelValidate\Utils;
 
 interface CountryLandlineValidator
 {

--- a/src/Utils/CountryLandlineValidator/CMLandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/CMLandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class CMLandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryLandlineValidator/DELandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/DELandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class DELandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryLandlineValidator/ENLandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/ENLandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class ENLandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryLandlineValidator/ESLandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/ESLandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class ESLandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryLandlineValidator/FRLandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/FRLandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class FRLandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryLandlineValidator/GRLandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/GRLandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class GRLandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryLandlineValidator/IDLandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/IDLandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class IDLandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryLandlineValidator/INLandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/INLandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class INLandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryLandlineValidator/IRLandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/IRLandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class IRLandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryLandlineValidator/ITLandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/ITLandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class ITLandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryLandlineValidator/JALandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/JALandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class JALandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryLandlineValidator/KOLandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/KOLandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class KOLandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryLandlineValidator/NELandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/NELandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class NELandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryLandlineValidator/RULandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/RULandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class RULandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryLandlineValidator/SALandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/SALandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class SALandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryLandlineValidator/SELandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/SELandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class SELandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryLandlineValidator/TRLandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/TRLandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class TRLandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryLandlineValidator/ZHLandlineValidator.php
+++ b/src/Utils/CountryLandlineValidator/ZHLandlineValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryLandlineValidator;
 
+use Milwad\LaravelValidate\Utils\CountryLandlineValidator;
+
 class ZHLandlineValidator implements CountryLandlineValidator
 {
     /**

--- a/src/Utils/CountryPhoneCallback.php
+++ b/src/Utils/CountryPhoneCallback.php
@@ -2,7 +2,6 @@
 
 namespace Milwad\LaravelValidate\Utils;
 
-use Milwad\LaravelValidate\Utils\CountryPhoneValidator\CountryPhoneValidator;
 use RuntimeException;
 
 class CountryPhoneCallback

--- a/src/Utils/CountryPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+namespace Milwad\LaravelValidate\Utils;
 
 interface CountryPhoneValidator
 {

--- a/src/Utils/CountryPhoneValidator/CMPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/CMPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class CMPhoneValidator implements CountryPhoneValidator
 {
     public function validate($value): bool

--- a/src/Utils/CountryPhoneValidator/DEPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/DEPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class DEPhoneValidator implements CountryPhoneValidator
 {
     /**

--- a/src/Utils/CountryPhoneValidator/ENPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/ENPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class ENPhoneValidator implements CountryPhoneValidator
 {
     /**

--- a/src/Utils/CountryPhoneValidator/ESPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/ESPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class ESPhoneValidator implements CountryPhoneValidator
 {
     /**

--- a/src/Utils/CountryPhoneValidator/FRPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/FRPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class FRPhoneValidator implements CountryPhoneValidator
 {
     /**

--- a/src/Utils/CountryPhoneValidator/GRPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/GRPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class GRPhoneValidator implements CountryPhoneValidator
 {
     /**

--- a/src/Utils/CountryPhoneValidator/IDPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/IDPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class IDPhoneValidator implements CountryPhoneValidator
 {
     /**

--- a/src/Utils/CountryPhoneValidator/INPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/INPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class INPhoneValidator implements CountryPhoneValidator
 {
     /**

--- a/src/Utils/CountryPhoneValidator/IRPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/IRPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class IRPhoneValidator implements CountryPhoneValidator
 {
     /**

--- a/src/Utils/CountryPhoneValidator/ITPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/ITPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class ITPhoneValidator implements CountryPhoneValidator
 {
     /**

--- a/src/Utils/CountryPhoneValidator/JAPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/JAPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class JAPhoneValidator implements CountryPhoneValidator
 {
     /**

--- a/src/Utils/CountryPhoneValidator/KOPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/KOPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class KOPhoneValidator implements CountryPhoneValidator
 {
     /**

--- a/src/Utils/CountryPhoneValidator/NEPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/NEPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class NEPhoneValidator implements CountryPhoneValidator
 {
     /**

--- a/src/Utils/CountryPhoneValidator/RUPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/RUPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class RUPhoneValidator implements CountryPhoneValidator
 {
     /**

--- a/src/Utils/CountryPhoneValidator/SAPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/SAPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class SAPhoneValidator implements CountryPhoneValidator
 {
     /**

--- a/src/Utils/CountryPhoneValidator/SEPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/SEPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class SEPhoneValidator implements CountryPhoneValidator
 {
     /**

--- a/src/Utils/CountryPhoneValidator/TRPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/TRPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class TRPhoneValidator implements CountryPhoneValidator
 {
     /**

--- a/src/Utils/CountryPhoneValidator/ZHPhoneValidator.php
+++ b/src/Utils/CountryPhoneValidator/ZHPhoneValidator.php
@@ -2,6 +2,8 @@
 
 namespace Milwad\LaravelValidate\Utils\CountryPhoneValidator;
 
+use Milwad\LaravelValidate\Utils\CountryPhoneValidator;
+
 class ZHPhoneValidator implements CountryPhoneValidator
 {
     /**


### PR DESCRIPTION
## Summary

This PR restructures the phone/landline validator to comply with the Dependency Inversion and Clean Architecture by separating abstraction from low-level implementation.

## Changes

- Moved:
  - CountryLandlineValidator
  - CountryPhoneValidator
- Placed interfaces at a higher level

## Reference

A similar approach is used by Mr [Iman Ghafoori](https://github.com/imanghafoori1) in package [laravel-widgetize](https://github.com/imanghafoori1/laravel-widgetize/tree/master/src/Utils)

`NormalizerContract.php` is located at a higher level and separated from the `Normalizers` directory.
